### PR TITLE
Add Context7 documentation lookup tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ so per-user settings live in one place instead of being exported every shell.
 | `MINION_ACTIVE` | name of the source to start on (same as `--source`, but persistent; defaults to the first in `MINION_SOURCES`) |
 | `TOGETHER_API_KEY` | auto-registers a built-in `together` source (Together AI, default model `zai-org/GLM-5.2`); override with `MINION_SOURCE_TOGETHER_*` |
 | `OPENROUTER_API_KEY` | auto-registers a built-in `openrouter` source (OpenRouter, default model `z-ai/glm-5.2` routed to `parasail/fp8`); override with `MINION_SOURCE_OPENROUTER_*` |
+| `MINION_CONTEXT7` | set to `1` to enable the `lookup_docs` tool (fetches up-to-date library docs via Context7 MCP server; requires Node.js/npx) |
 | `MINION_BACKEND` | set to `vllm` to disable llama.cpp-only recovery knobs (`min_p`, `repeat_penalty`, DRY) that vLLM's speculative decoder rejects |
 | `MINION_SOURCE_<NAME>_EXTRA_BODY` | JSON object merged into every chat request body for that source (used by OpenRouter's provider routing); invalid JSON is warned to stderr and ignored |
 | `MINION_SOURCE_<NAME>_APP_NAME` / `MINION_SOURCE_<NAME>_APP_URL` | HTTP-Referer / X-Title headers for aggregator identification (OpenRouter dashboard) |

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ so per-user settings live in one place instead of being exported every shell.
 | `MINION_ACTIVE` | name of the source to start on (same as `--source`, but persistent; defaults to the first in `MINION_SOURCES`) |
 | `TOGETHER_API_KEY` | auto-registers a built-in `together` source (Together AI, default model `zai-org/GLM-5.2`); override with `MINION_SOURCE_TOGETHER_*` |
 | `OPENROUTER_API_KEY` | auto-registers a built-in `openrouter` source (OpenRouter, default model `z-ai/glm-5.2` routed to `parasail/fp8`); override with `MINION_SOURCE_OPENROUTER_*` |
-| `MINION_CONTEXT7` | set to `1` to enable the `lookup_docs` tool (fetches up-to-date library docs via Context7 MCP server; requires Node.js/npx) |
+| `MINION_CONTEXT7` | `lookup_docs` tool is enabled by default; set to `0` to disable (fetches up-to-date library docs via Context7 MCP server; requires Node.js/npx) |
 | `MINION_BACKEND` | set to `vllm` to disable llama.cpp-only recovery knobs (`min_p`, `repeat_penalty`, DRY) that vLLM's speculative decoder rejects |
 | `MINION_SOURCE_<NAME>_EXTRA_BODY` | JSON object merged into every chat request body for that source (used by OpenRouter's provider routing); invalid JSON is warned to stderr and ignored |
 | `MINION_SOURCE_<NAME>_APP_NAME` / `MINION_SOURCE_<NAME>_APP_URL` | HTTP-Referer / X-Title headers for aggregator identification (OpenRouter dashboard) |

--- a/changelog.md
+++ b/changelog.md
@@ -4,10 +4,10 @@ All notable changes to `minion.py` from this point forward.
 
 ### Added — Context7 documentation lookup tool
 
-New opt-in `lookup_docs` tool fetches up-to-date library/framework documentation
-via the Context7 MCP server. Enable with `MINION_CONTEXT7=1` (requires Node.js /
-npx). The agent can now call `lookup_docs("react", "hooks")` to get current API
-docs instead of relying on training data.
+New `lookup_docs` tool fetches up-to-date library/framework documentation via the
+Context7 MCP server. Enabled by default (disable with `MINION_CONTEXT7=0`;
+requires Node.js/npx). The agent can now call `lookup_docs("react", "hooks")` to
+get current API docs instead of relying on training data.
 
 - Lazily spawns `npx -y @upstash/context7-mcp` on first use, reuses the process
 - Combines resolve-library-id + get-library-docs into a single tool call

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,18 @@
 
 All notable changes to `minion.py` from this point forward.
 
+### Added — Context7 documentation lookup tool
+
+New opt-in `lookup_docs` tool fetches up-to-date library/framework documentation
+via the Context7 MCP server. Enable with `MINION_CONTEXT7=1` (requires Node.js /
+npx). The agent can now call `lookup_docs("react", "hooks")` to get current API
+docs instead of relying on training data.
+
+- Lazily spawns `npx -y @upstash/context7-mcp` on first use, reuses the process
+- Combines resolve-library-id + get-library-docs into a single tool call
+- Zero token overhead when disabled (tool schema not included in requests)
+- Process auto-cleaned on agent exit via atexit
+
 ### Added — OpenRouter built-in source with provider routing
 
 New built-in `openrouter` source auto-registers when `OPENROUTER_API_KEY` is

--- a/minion.py
+++ b/minion.py
@@ -1547,7 +1547,7 @@ def run_bash(command, **_):
     return f"[exit {r.returncode}]\n{out[:200000]}"
 
 
-# --- context7 documentation lookup (opt-in via MINION_CONTEXT7=1) -----------
+# --- context7 documentation lookup (disable with MINION_CONTEXT7=0) ----------
 
 class _Context7:
     """Minimal MCP client for the Context7 documentation server."""
@@ -1594,28 +1594,28 @@ class _Context7:
         self._proc.stdin.write(msg + "\n")
         self._proc.stdin.flush()
 
-    def resolve(self, library):
+    def resolve(self, library, topic=""):
         result = self._call("tools/call", {
             "name": "resolve-library-id",
-            "arguments": {"libraryName": library},
+            "arguments": {"libraryName": library,
+                          "query": topic or library},
         })
-        content = result.get("content") or [] if isinstance(result, dict) else []
+        content = (result.get("content") or []) if isinstance(result, dict) else []
         for item in content:
             if isinstance(item, dict) and item.get("type") == "text":
                 text = item.get("text", "")
-                if text.strip():
-                    return text.strip()
+                match = re.search(r"Context7-compatible library ID:\s*(\S+)", text)
+                if match:
+                    return match.group(1)
         return None
 
     def get_docs(self, library_id, topic=""):
-        args = {"context7CompatibleLibraryID": library_id}
-        if topic:
-            args["topic"] = topic
         result = self._call("tools/call", {
-            "name": "get-library-docs",
-            "arguments": args,
+            "name": "query-docs",
+            "arguments": {"libraryId": library_id,
+                          "query": topic or "overview"},
         })
-        content = result.get("content") or [] if isinstance(result, dict) else []
+        content = (result.get("content") or []) if isinstance(result, dict) else []
         parts = []
         for item in content:
             if isinstance(item, dict) and item.get("type") == "text":
@@ -1651,7 +1651,7 @@ def lookup_docs(library, topic="", **_):
     if _ctx7 is None:
         _ctx7 = _Context7()
     _ctx7._ensure()
-    lib_id = _ctx7.resolve(library)
+    lib_id = _ctx7.resolve(library, topic)
     if not lib_id:
         return f"No library found matching '{library}'"
     docs = _ctx7.get_docs(lib_id, topic)

--- a/minion.py
+++ b/minion.py
@@ -45,8 +45,8 @@ Env:   MINION_APPROVAL=<all|low|medium|high|yolo>  (persistent default approval 
        TOGETHER_API_KEY  (auto-registers a built-in `together` source; default model zai-org/GLM-5.2)
        OPENROUTER_API_KEY  (auto-registers a built-in `openrouter` source; default model z-ai/glm-5.2,
             routed to parasail/fp8 — override with /provider or MINION_SOURCE_OPENROUTER_EXTRA_BODY)
-       MINION_CONTEXT7=1  (enables the lookup_docs tool — fetches up-to-date library docs via Context7
-            MCP server; requires Node.js/npx installed)
+       MINION_CONTEXT7=0  (disables the lookup_docs tool; enabled by default — fetches up-to-date library
+            docs via Context7 MCP server; requires Node.js/npx installed)
 """
 import atexit
 import json
@@ -1678,7 +1678,7 @@ TOOLS = [
         "parameters": {"type": "object", "properties": {"command": {"type": "string"}}, "required": ["command"]}}},
 ]
 
-if os.environ.get("MINION_CONTEXT7", "").strip():
+if os.environ.get("MINION_CONTEXT7", "1").strip() != "0":
     DISPATCH["lookup_docs"] = lookup_docs
     TOOLS.append({"type": "function", "function": {
         "name": "lookup_docs",

--- a/minion.py
+++ b/minion.py
@@ -45,7 +45,10 @@ Env:   MINION_APPROVAL=<all|low|medium|high|yolo>  (persistent default approval 
        TOGETHER_API_KEY  (auto-registers a built-in `together` source; default model zai-org/GLM-5.2)
        OPENROUTER_API_KEY  (auto-registers a built-in `openrouter` source; default model z-ai/glm-5.2,
             routed to parasail/fp8 — override with /provider or MINION_SOURCE_OPENROUTER_EXTRA_BODY)
+       MINION_CONTEXT7=1  (enables the lookup_docs tool — fetches up-to-date library docs via Context7
+            MCP server; requires Node.js/npx installed)
 """
+import atexit
 import json
 import os
 import random
@@ -1544,6 +1547,119 @@ def run_bash(command, **_):
     return f"[exit {r.returncode}]\n{out[:200000]}"
 
 
+# --- context7 documentation lookup (opt-in via MINION_CONTEXT7=1) -----------
+
+class _Context7:
+    """Minimal MCP client for the Context7 documentation server."""
+
+    def __init__(self):
+        self._proc = None
+        self._id = 0
+
+    def _ensure(self):
+        if self._proc and self._proc.poll() is None:
+            return
+        try:
+            self._proc = subprocess.Popen(
+                ["npx", "-y", "@upstash/context7-mcp"],
+                stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL, text=True)
+        except FileNotFoundError:
+            raise RuntimeError("npx not found — install Node.js to use lookup_docs")
+        self._call("initialize", {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "minion", "version": "0.1"},
+        })
+        self._notify("notifications/initialized", {})
+
+    def _call(self, method, params):
+        self._id += 1
+        msg = json.dumps({"jsonrpc": "2.0", "id": self._id,
+                          "method": method, "params": params})
+        self._proc.stdin.write(msg + "\n")
+        self._proc.stdin.flush()
+        while True:
+            line = self._proc.stdout.readline()
+            if not line:
+                raise RuntimeError("Context7 process exited unexpectedly")
+            resp = json.loads(line)
+            if "id" in resp:
+                if "error" in resp:
+                    raise RuntimeError(resp["error"].get("message", resp["error"]))
+                return resp.get("result")
+
+    def _notify(self, method, params):
+        msg = json.dumps({"jsonrpc": "2.0", "method": method, "params": params})
+        self._proc.stdin.write(msg + "\n")
+        self._proc.stdin.flush()
+
+    def resolve(self, library):
+        result = self._call("tools/call", {
+            "name": "resolve-library-id",
+            "arguments": {"libraryName": library},
+        })
+        content = result.get("content") or [] if isinstance(result, dict) else []
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                text = item.get("text", "")
+                if text.strip():
+                    return text.strip()
+        return None
+
+    def get_docs(self, library_id, topic=""):
+        args = {"context7CompatibleLibraryID": library_id}
+        if topic:
+            args["topic"] = topic
+        result = self._call("tools/call", {
+            "name": "get-library-docs",
+            "arguments": args,
+        })
+        content = result.get("content") or [] if isinstance(result, dict) else []
+        parts = []
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                text = item.get("text", "")
+                if text.strip():
+                    parts.append(text.strip())
+        return "\n\n".join(parts) if parts else None
+
+    def close(self):
+        if self._proc and self._proc.poll() is None:
+            self._proc.terminate()
+            try:
+                self._proc.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                self._proc.kill()
+        self._proc = None
+
+
+_ctx7 = None
+
+
+def _ctx7_cleanup():
+    if _ctx7 is not None:
+        _ctx7.close()
+
+
+atexit.register(_ctx7_cleanup)
+
+
+def lookup_docs(library, topic="", **_):
+    """Look up library documentation via Context7 MCP server."""
+    global _ctx7
+    if _ctx7 is None:
+        _ctx7 = _Context7()
+    _ctx7._ensure()
+    lib_id = _ctx7.resolve(library)
+    if not lib_id:
+        return f"No library found matching '{library}'"
+    docs = _ctx7.get_docs(lib_id, topic)
+    if not docs:
+        return f"No documentation found for '{library}' on topic '{topic}'"
+    return f"[Context7: {lib_id}]\n\n{docs}"
+
+
 DISPATCH = {
     "read_file": read_file, "write_file": write_file, "edit_file": edit_file,
     "list_dir": list_dir, "run_bash": run_bash,
@@ -1561,6 +1677,17 @@ TOOLS = [
     {"type": "function", "function": {"name": "run_bash", "description": "Run a shell command",
         "parameters": {"type": "object", "properties": {"command": {"type": "string"}}, "required": ["command"]}}},
 ]
+
+if os.environ.get("MINION_CONTEXT7", "").strip():
+    DISPATCH["lookup_docs"] = lookup_docs
+    TOOLS.append({"type": "function", "function": {
+        "name": "lookup_docs",
+        "description": "Look up current documentation for a library/framework via Context7. Use when you need accurate, up-to-date API docs rather than relying on training data.",
+        "parameters": {"type": "object", "properties": {
+            "library": {"type": "string", "description": "Library name (e.g. 'nextjs', 'react', 'fastapi')"},
+            "topic": {"type": "string", "description": "Specific topic to focus on (e.g. 'routing', 'middleware')"},
+        }, "required": ["library"]},
+    }})
 
 FINAL_ANSWER_TOOL = {"type": "function", "function": {
     "name": "final_answer",


### PR DESCRIPTION
## Summary
- Adds `lookup_docs` tool that fetches up-to-date library/framework documentation via the Context7 MCP server
- Lazily spawns `npx -y @upstash/context7-mcp` on first use, reuses the process across calls, auto-cleans on exit
- Enabled by default (disable with `MINION_CONTEXT7=0`); zero token overhead when disabled (tool schema not included)
- Fixes MCP client to match Context7 server v3.2.2 API (`resolve-library-id` requires `query` param, docs tool is `query-docs` not `get-library-docs`, response parsing extracts library ID via regex)

## Test plan
- [x] Verified `lookup_docs("react", "hooks")` returns real documentation
- [x] Verified `lookup_docs("fastapi", "middleware")`, `lookup_docs("nextjs", "routing")`, `lookup_docs("django")`, `lookup_docs("vue.js", "composables")`, `lookup_docs("express", "middleware")`, `lookup_docs("flask", "blueprints")` all work
- [x] Process reuse confirmed (same PID across calls)
- [x] Process recovery after kill (auto-restarts)
- [x] Edge cases: empty string, 500-char name, Unicode input — no crashes
- [x] `MINION_CONTEXT7=0` correctly disables the tool
- [x] `npx` not found raises clear RuntimeError
- [x] `close()` safe on None/double-call